### PR TITLE
Disabled bytecompiling and .build-id when building RPM

### DIFF
--- a/bfb2image.spec
+++ b/bfb2image.spec
@@ -9,6 +9,9 @@ Source: %{name}-%{version}.tar.gz
 BuildRoot: %{?build_root:%{build_root}}%{!?build_root:/var/tmp/%{name}-%{version}-root}
 Vendor: Nvidia
 
+# Disable bytecompiling
+%global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
+
 %description
 This script takes an bfb and create from it a VM image.
 

--- a/bfb2image.spec
+++ b/bfb2image.spec
@@ -12,6 +12,9 @@ Vendor: Nvidia
 # Disable bytecompiling
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
 
+# Disable .build-id
+%define _build_id_links none
+
 %description
 This script takes an bfb and create from it a VM image.
 


### PR DESCRIPTION
Building on CentOS 7 based systems will fail due to the python2 being the default and it also attempts to bytecompile here which is unnecessary here

Also disables .build-id for centos 8 systems

Signed-off-by: Orsan Awwad <oawwad@nvidia.com>