### PR TITLE
Modify mlnx_bf_configure to support SimX.

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -19,6 +19,7 @@ ADD bfb_tool_raw_img.sh .
 
 ADD $bfb .
 ADD mlx-mkbfb.py .
+ADD mlnx_bf_configure .
 RUN apt-get update -y
 RUN apt-get install -y qemu-user-static
 RUN apt-get install -y python3

--- a/src/bfb_to_raw_img.sh
+++ b/src/bfb_to_raw_img.sh
@@ -127,6 +127,7 @@ mkdir -p $WDIR
 cp    Dockerfile \
       bfb_tool_raw_img.sh \
       mlx-mkbfb.py \
+      mlnx_bf_configure \
       qemu-aarch64-static \
       $bfb \
       $WDIR

--- a/src/bfb_tool_raw_img.sh
+++ b/src/bfb_tool_raw_img.sh
@@ -33,6 +33,7 @@ bfb_img=${bfb%.*}.img
 tmp_dir="img_from_bfb_tmp_"$(date +"%T")
 git_repo="https://github.com/Mellanox/bfscripts.git"
 mkbfb_path=`realpath mlx-mkbfb.py`
+mlnx_bf_configure_path=`realpath mlnx_bf_configure`
 
 #create tmp directory
 if [ ! -d "$tmp_dir" ]; then
@@ -195,6 +196,25 @@ if [ -n "${ubuntu_PASSWORD}" ]; then
 else
     perl -ni -e "print unless /plain_text_passwd/" mnt/var/lib/cloud/seed/nocloud-net/user-data
 fi
+
+#modify mlnx_bf_configure script
+log "INFO: modify mlnx_bf_configure script to support SimX"
+if [ ! -e "$mlnx_bf_configure_path" ]; then
+    log "ERROR: can't find mlnx_bf_configure script"
+    exit 1
+fi
+
+mv mnt/sbin/mlnx_bf_configure mnt/sbin/mlnx_bf_configure.orig
+if [ $? -ne 0 ]; then
+    log "ERROR: Couldn't modify mlnx_bf_configure original name"
+fi
+
+log "INFO: move $mlnx_bf_configure_path to mnt/sbin/mlnx_bf_configure"
+mv $mlnx_bf_configure_path mnt/sbin/mlnx_bf_configure
+if [ $? -ne 0 ]; then
+    log "ERROR: Couldn't copy $mlnx_bf_configure_path to mnt/sbin/mlnx_bf_configure"
+fi
+chmod 777 mnt/sbin/mlnx_bf_configure
 
 #configure network settings
 log "INFO: modify network settings"

--- a/src/mlnx_bf_configure
+++ b/src/mlnx_bf_configure
@@ -1,0 +1,41 @@
+#!/usr/bin/bash 
+# Original mlnx_bf_configure script is located at /sbin/mlnx_bf_configure.orig
+# Temporary script. Need to support same flow as /sbin/mlnx_bf_configure.orig
+
+is_bf=`lspci | grep BlueField | wc -l`
+if [ $is_bf -ne 1 ]; then
+        exit 0
+fi
+
+info()
+{
+                logger -t $prog -i "INFO: $*"
+}
+
+error()
+{
+                logger -t $prog -i "ERR: $*"
+}
+
+set_eswitch_mode()
+{
+        pci_dev=$1
+        mode=$2
+        shift 2
+
+        sudo devlink dev eswitch set pci/${pci_dev} mode ${mode}
+       echo "devlink dev eswitch set pci/$pci_dev mode $mode"
+        rc=$?
+        if [ $rc -ne 0 ]; then
+                error "Failed to configure ${mode} mode for ${pci_dev}"
+        else
+                info "Configured ${mode} mode for ${pci_dev}"
+        fi
+
+        return $rc
+}
+
+for dev in `lspci -nD -d 15b3: | grep 'a2d[26c]' | cut -d ' ' -f 1`
+do
+        set_eswitch_mode ${dev} switchdev
+done


### PR DESCRIPTION
Original mlnx_bf_configure doesn't support SimX because it uses tools like mftconfig that read from flash.
mlnx_bf_configure sets Bluefiels devices into swtichdev mode. In order to set SimX Bluefield devices into switchdev mode, mlnx_bf_configure was modified to support SimX.

Signed-off-by: Emanuel Alkobi <ealkobi@nvidia.com>