### PR TITLE
Disable dts service for simx images

### DIFF
--- a/src/bfb_to_raw_img.sh
+++ b/src/bfb_to_raw_img.sh
@@ -182,15 +182,14 @@ docker run -t --rm --privileged -e container=docker \
 
 if [ $? -ne 0 ]; then
     log "ERROR: Couldn't create successfully VM image"
+    exit 1
 fi
 
 #copy img to output path
 log "INFO: copy ${bfb_basename%.*}.img to $out_path"
 mv $WDIR/${bfb_basename%.*}.img $out_path
-
 log "INFO: removing $WDIR"
 rm $WDIR -rf
-
 log "INFO: removing image create_img_runtime_$id"
 docker image rm $img_name
 

--- a/src/bfb_to_raw_img.sh
+++ b/src/bfb_to_raw_img.sh
@@ -182,14 +182,15 @@ docker run -t --rm --privileged -e container=docker \
 
 if [ $? -ne 0 ]; then
     log "ERROR: Couldn't create successfully VM image"
-    exit 1
 fi
 
 #copy img to output path
 log "INFO: copy ${bfb_basename%.*}.img to $out_path"
 mv $WDIR/${bfb_basename%.*}.img $out_path
+
 log "INFO: removing $WDIR"
 rm $WDIR -rf
+
 log "INFO: removing image create_img_runtime_$id"
 docker image rm $img_name
 

--- a/src/bfb_tool_raw_img.sh
+++ b/src/bfb_tool_raw_img.sh
@@ -217,11 +217,13 @@ fi
 # Increase openibd timeout to support multiple devices
 sed -r -i -e "s/(TimeoutSec=).*/\118000/" mnt/lib/systemd/system/openibd.service
 
-# WA: set DTS telemetry update=0 in config for simx/Air image
-DTS_CONFIG="mnt/opt/mellanox/doca/services/telemetry/config/dts_config.ini"
-if [ -f "$DTS_CONFIG" ]; then
-	log "INFO: applying DTS workaround: update=0 in dts_config.ini"
-	sed -i 's/^update=[0-9]*/update=0/' "$DTS_CONFIG"
+# WA: DTS for simx/Air - copy DTS yaml to /etc/kubelet.d.disabled/ so kubelet does not load it
+IMPORT_DOCA_TELEMETRY="mnt/opt/mellanox/doca/services/telemetry/import_doca_telemetry.sh"
+if [ -f "$IMPORT_DOCA_TELEMETRY" ]; then
+	sed -i -e 's|/etc/kubelet\.d/|/etc/kubelet.d.disabled/|g' "$IMPORT_DOCA_TELEMETRY"
+	# ensure script creates .disabled dir before cp (insert mkdir -p before the cp line if needed)
+	sed -i -e '\|/etc/kubelet.d.disabled/|s|^ex cp|ex mkdir -p /etc/kubelet.d.disabled \&\& ex cp|' "$IMPORT_DOCA_TELEMETRY"
+	log "INFO: DTS workaround: DTS yaml will be copied to /etc/kubelet.d.disabled/ (not loaded by kubelet)"
 fi
 
 # Ubuntu 24.04

--- a/src/bfb_tool_raw_img.sh
+++ b/src/bfb_tool_raw_img.sh
@@ -178,6 +178,12 @@ fi
 rm -f mnt/etc/systemd/system/multi-user.target.wants/set_emu_param.service
 rm -f mnt/etc/systemd/system/multi-user.target.wants/mlx_ipmid.service
 
+# Disable Collectx (dpeserver) on Air/simx image - saves memory; not needed for perf/counters there
+# MAHMOUD CHANGE
+log "INFO: disabling Collectx (dpeserver) service for simx/Air image"
+chroot mnt systemctl disable dpeserver.service 2>/dev/null || true
+chroot mnt systemctl mask dpeserver.service 2>/dev/null || true
+
 #create EFI/ubuntu/grub.cfg
 root='$root'
 prefix='$prefix'

--- a/src/bfb_tool_raw_img.sh
+++ b/src/bfb_tool_raw_img.sh
@@ -178,10 +178,6 @@ fi
 rm -f mnt/etc/systemd/system/multi-user.target.wants/set_emu_param.service
 rm -f mnt/etc/systemd/system/multi-user.target.wants/mlx_ipmid.service
 
-# Disable Collectx (dpeserver) on Air/simx image to enchance performance, not needed for perf/counters there
-log "INFO: disabling Collectx (dpeserver) service for simx/Air image"
-chroot mnt systemctl disable dpeserver.service 2>/dev/null
-
 #create EFI/ubuntu/grub.cfg
 root='$root'
 prefix='$prefix'
@@ -220,6 +216,13 @@ fi
 
 # Increase openibd timeout to support multiple devices
 sed -r -i -e "s/(TimeoutSec=).*/\118000/" mnt/lib/systemd/system/openibd.service
+
+# WA: set DTS telemetry update=0 in config for simx/Air image
+DTS_CONFIG="mnt/opt/mellanox/doca/services/telemetry/config/dts_config.ini"
+if [ -f "$DTS_CONFIG" ]; then
+	log "INFO: applying DTS workaround: update=0 in dts_config.ini"
+	sed -i 's/^update=[0-9]*/update=0/' "$DTS_CONFIG"
+fi
 
 # Ubuntu 24.04
 if [[ "$(grep -oP '(?<=VERSION_ID=).*' mnt/etc/os-release | tr -d '"')" == "24.04" ]]; then

--- a/src/bfb_tool_raw_img.sh
+++ b/src/bfb_tool_raw_img.sh
@@ -217,13 +217,12 @@ fi
 # Increase openibd timeout to support multiple devices
 sed -r -i -e "s/(TimeoutSec=).*/\118000/" mnt/lib/systemd/system/openibd.service
 
-# WA: DTS for simx/Air - copy DTS yaml to /etc/kubelet.d.disabled/ so kubelet does not load it
+# WA: DTS for simx/Air - comment out the line that copies DTS yaml to /etc/kubelet.d/ so kubelet does not load it and DTS is disabled
+# to enable DTS, uncomment the line that copies DTS yaml to /etc/kubelet.d/ and re run the script
 IMPORT_DOCA_TELEMETRY="mnt/opt/mellanox/doca/services/telemetry/import_doca_telemetry.sh"
 if [ -f "$IMPORT_DOCA_TELEMETRY" ]; then
-	sed -i -e 's|/etc/kubelet\.d/|/etc/kubelet.d.disabled/|g' "$IMPORT_DOCA_TELEMETRY"
-	# ensure script creates .disabled dir before cp (insert mkdir -p before the cp line if needed)
-	sed -i -e '\|/etc/kubelet.d.disabled/|s|^ex cp|ex mkdir -p /etc/kubelet.d.disabled \&\& ex cp|' "$IMPORT_DOCA_TELEMETRY"
-	log "INFO: DTS workaround: DTS yaml will be copied to /etc/kubelet.d.disabled/ (not loaded by kubelet)"
+	sed -i -e '\|ex cp.*/etc/kubelet\.d/|s|^|# |' "$IMPORT_DOCA_TELEMETRY"
+	log "INFO: DTS workaround: commented out 'ex cp ... /etc/kubelet.d/' (DTS yaml not loaded by kubelet)"
 fi
 
 # Ubuntu 24.04

--- a/src/bfb_tool_raw_img.sh
+++ b/src/bfb_tool_raw_img.sh
@@ -178,11 +178,9 @@ fi
 rm -f mnt/etc/systemd/system/multi-user.target.wants/set_emu_param.service
 rm -f mnt/etc/systemd/system/multi-user.target.wants/mlx_ipmid.service
 
-# Disable Collectx (dpeserver) on Air/simx image - saves memory; not needed for perf/counters there
-# MAHMOUD CHANGE
+# Disable Collectx (dpeserver) on Air/simx image to enchance performance, not needed for perf/counters there
 log "INFO: disabling Collectx (dpeserver) service for simx/Air image"
-chroot mnt systemctl disable dpeserver.service 2>/dev/null || true
-chroot mnt systemctl mask dpeserver.service 2>/dev/null || true
+chroot mnt systemctl disable dpeserver.service 2>/dev/null
 
 #create EFI/ubuntu/grub.cfg
 root='$root'


### PR DESCRIPTION
Dts service consumes alot of memory and affects performance
in general simx does not need this service at all, as we dont check performance or read counters there.

issue number: 4888010